### PR TITLE
Prompt user for credentials when left unspecified

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -1,4 +1,10 @@
+import getpass
+
 # Put your User/Pass in here!
 
 username='YourUsername'
 password='YourPassword'
+
+if username == 'YourUsername' and password == 'YourPassword':
+    username = raw_input('Github Username: ')
+    password = getpass.getpass('Github Password: ')


### PR DESCRIPTION
I don't feel comfortable putting my password in a text file on some machines, so I added a fallback method which prompts the user for their username and password when they have not been specified in `settings.py`.
